### PR TITLE
[WIP] Link to libavisynth on *nix, or else the plugin won't work.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,8 +36,9 @@ endif()
 
 IF (NOT WIN32 OR MINGW)
   FIND_PACKAGE(PkgConfig REQUIRED)
+  PKG_CHECK_MODULES(AVISYNTH REQUIRED avisynth>=3.5.0)
   PKG_CHECK_MODULES(LIBASS REQUIRED libass>=0.12.0)
-  target_include_directories(${PluginName} PRIVATE ${LIBASS_INCLUDE_DIR})
+  target_include_directories(${PluginName} PRIVATE ${AVISYNTH_INCLUDE_DIR} ${LIBASS_INCLUDE_DIR})
 ENDIF()
 
 #dedicated include dir for avisynth.h
@@ -57,7 +58,7 @@ if (WIN32)
     TARGET_LINK_LIBRARIES(${ProjectName} ${AVS_LIBDIR}/avisynth.lib)
   endif()
 else()
-  TARGET_LINK_LIBRARIES(${ProjectName} ${LIBASS_LDFLAGS} )
+  TARGET_LINK_LIBRARIES(${ProjectName} ${AVISYNTH_LDFLAGS} ${LIBASS_LDFLAGS} )
 endif()
 
 include(GNUInstallDirs)

--- a/src/assrender.h
+++ b/src/assrender.h
@@ -6,7 +6,11 @@
 #include <math.h>
 #include <string.h>
 #include <ass/ass.h>
+#ifdef AVS_WINDOWS
 #include "avisynth_c.h"
+#else
+#include <avisynth/avisynth_c.h>
+#endif
 
 #if defined(_MSC_VER)
 #define __NO_ISOCEXT


### PR DESCRIPTION
The barest minimum part here is linking libavisynth into libassrender, allowing avs_add_function to be found and the plugin to function.

For ease of use, this is done using pkg-config, and the bit in `src/assrender.h` that looks for avisynth_c.h locally instead looks for it on the system in non-WIN32 cases.

Things maybe to-do with discussion:
* Instead of trying to locate avisynth.lib somewhere in the plugin's source tree, hook it to the value of AVISYNTH_SDK_PATH when MSVC is being used (and maybe MinGW, unless testing proves that C-plugins can just go ahead and link to avisynth.dll.a without incident), so that we could just use the existing install of the FilterSDK.  Perhaps more important of a distinction when dealing with cross-compiling.